### PR TITLE
Fixed pip installation command line instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Small python class which converts Robot Framework Libdoc XML Files to JSON that 
 
 **Installation**:
 
-    pip install libdoc2json
+    pip install robotframework-libdoc2json
 
 **Usage**:
 


### PR DESCRIPTION
Readme has a wrong Pypi project name, pip instruction doesn't work.